### PR TITLE
Fix deprecation warning for php 7.4

### DIFF
--- a/lib/oauth-php/library/signature_method/OAuthSignatureMethod_MD5.php
+++ b/lib/oauth-php/library/signature_method/OAuthSignatureMethod_MD5.php
@@ -60,7 +60,7 @@ class OAuthSignatureMethod_MD5 extends OAuthSignatureMethod
 		
 		for ($i = 0; $i < strlen($md5); $i += 2)
 		{
-		    $bin .= chr(hexdec($md5{$i+1}) + hexdec($md5{$i}) * 16);
+		    $bin .= chr(hexdec($md5[$i+1]) + hexdec($md5[$i]) * 16);
 		}
 		return $request->urlencode(base64_encode($bin));
 	}


### PR DESCRIPTION
Array and string offset access syntax with curly braces is deprecated